### PR TITLE
Using a much faster go proxy server

### DIFF
--- a/.github/OWNERS
+++ b/.github/OWNERS
@@ -1,0 +1,18 @@
+approvers:
+    - pixiake
+    - Forest-L
+    - rayzhou2017
+    - LinuxSuRen
+
+reviewers:
+    - pixiake
+    - Forest-L
+    - rayzhou2017
+    - zryfish
+    - shaowenchen
+    - benjaminhuo
+    - calvinyv
+    - FeynmanZhou
+    - huanggze
+    - wansir
+    - LinuxSuRen

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    pull-request-branch-name:
+      separator: "-"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    pull-request-branch-name:
+      separator: "-"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,41 @@
+# Configuration for Release Drafter: https://github.com/toolmantim/release-drafter
+name-template: 'v$NEXT_PATCH_VERSION 🌈'
+tag-template: 'v$NEXT_PATCH_VERSION'
+version-template: $MAJOR.$MINOR.$PATCH
+# Emoji reference: https://gitmoji.carloscuesta.me/
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+      - 'kind/feature'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+      - 'regression'
+      - 'kind/bug'
+  - title: 📝 Documentation updates
+    labels:
+      - 'documentation'
+      - 'kind/documentation'
+  - title: 👻 Maintenance
+    labels:
+      - chore
+      - dependencies
+      - 'kind/cleanup'
+  - title: 🚦 Tests
+    labels: 
+      - test
+      - tests
+exclude-labels:
+  - reverted
+  - no-changelog
+  - skip-changelog
+  - invalid
+change-template: '* $TITLE (#$NUMBER) @$AUTHOR'
+template: |
+  ## What’s Changed
+
+  $CHANGES

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,29 @@
+repository:
+  name: kubeeye
+  description: "KubeEye aims to find various problems on Kubernetes, such as application misconfiguration, unhealthy cluster components and node problems."
+  homepage: https://kubesphere.io/
+  private: false
+  has_issues: true
+  has_wiki: false
+  has_downloads: false
+  default_branch: main
+  allow_squash_merge: true
+  allow_merge_commit: true
+  allow_rebase_merge: true
+branches:
+  - name: main
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+        dismiss_stale_reviews: true
+        require_code_owner_reviews: true
+        dismissal_restrictions:
+          users: []
+          teams: []
+      required_status_checks:
+        strict: true
+        contexts: []
+      enforce_admins: false
+      restrictions:
+        users: []
+        teams: []

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,15 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test: fmt
 	GO111MODULE=on go test -v ./pkg/...
 
 install-packr2:
-	GO111MODULE=on GOPROXY=https://proxy.golang.org CGO_ENABLED=0 go get -u github.com/gobuffalo/packr/v2/packr2
+	GO111MODULE=on GOPROXY=https://goproxy.io CGO_ENABLED=0 go get -u github.com/gobuffalo/packr/v2/packr2
 	$(GOBIN)/packr2 build -a -o ${BINARY} *.go
 
 ke: install-packr2


### PR DESCRIPTION
Test results from goproxy.io
```
➜  kubeye git:(change-goproxy) ✗ ping goproxy.io -c 3
PING goproxy.io (119.28.201.50): 56 data bytes
64 bytes from 119.28.201.50: icmp_seq=0 ttl=44 time=105.338 ms
64 bytes from 119.28.201.50: icmp_seq=1 ttl=44 time=154.306 ms
64 bytes from 119.28.201.50: icmp_seq=2 ttl=44 time=279.585 ms

--- goproxy.io ping statistics ---
3 packets transmitted, 3 packets received, 0.0% packet loss
round-trip min/avg/max/stddev = 105.338/179.743/279.585/73.375 ms
```

Test results from proxy.golang.org
```
➜  kubeye git:(change-goproxy) ✗ ping -c 3 proxy.golang.org
PING proxy.golang.org (172.217.160.81): 56 data bytes
Request timeout for icmp_seq 0
Request timeout for icmp_seq 1

--- proxy.golang.org ping statistics ---
3 packets transmitted, 0 packets received, 100.0% packet loss
```

As we can see from above, goproxy.io is much faster than another one. Also, you can get more details from the [website](https://goproxy.io/).

/kind cleanup