### PR TITLE
[FEATURE] add flag to ke install npd to support custom npd image.

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -22,6 +22,8 @@ import (
 	"kubeeye/pkg/validator"
 )
 
+var npdImage string
+
 var addCmd = &cobra.Command{
 	Use:   "install npd",
 	Short: "install the npd",
@@ -36,4 +38,5 @@ var addCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(addCmd)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	auditCmd.Flags().StringVarP(&npdImage, "image", "i", "k8s.gcr.io/node-problem-detector:v0.8.1", "Customize npd image")
 }

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -28,7 +28,7 @@ var addCmd = &cobra.Command{
 	Use:   "install npd",
 	Short: "install the npd",
 	Run: func(cmd *cobra.Command, args []string) {
-		err := validator.Add(cmd.Context())
+		err := validator.Add(cmd.Context(), npdImage)
 		if err != nil {
 			fmt.Println(err)
 		}
@@ -38,5 +38,5 @@ var addCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(addCmd)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
-	auditCmd.Flags().StringVarP(&npdImage, "image", "i", "k8s.gcr.io/node-problem-detector:v0.8.1", "Customize npd image")
+	addCmd.Flags().StringVarP(&npdImage, "image", "i", "k8s.gcr.io/node-problem-detector:v0.8.1", "Customize npd image")
 }

--- a/examples/daemonSet.yaml
+++ b/examples/daemonSet.yaml
@@ -22,7 +22,7 @@ spec:
             - --logtostderr
             - --apiserver-wait-timeout=10s
             - --config.system-log-monitor=/config/kernel-monitor.json,/config/docker-monitor.json
-          image: k8s.gcr.io/node-problem-detector:v0.8.1
+          image: {{.NpdImage}}
           resources:
             limits:
               cpu: 10m


### PR DESCRIPTION
`ke install npd` is convient to install npd in most cases.
But when in place where cannot pull from **k8s.gcr.io**(for example in China) it may become a really blocker for new users that just want a quick try.

And it enables ke to use another npd version other than the default 0.8.1.

This pr add an `--image` parameter to `ke install npd` to use their custom npd image to run npd.

```
ke install npd --image private-docker-registery/node-problem-detector:v0.8.1
# ke install npd -i private-docker-registery/node-problem-detector:v0.8.1 also works.
```