### PR TITLE
support a cluster health score

### DIFF
--- a/apis/kubeeye/v1alpha1/clusterinsight_types.go
+++ b/apis/kubeeye/v1alpha1/clusterinsight_types.go
@@ -60,12 +60,12 @@ type ClusterInfo struct {
 
 type AuditResults struct {
 	NameSpace    string            `json:"namespace"`
-	ResultInfos []ResultInfos `json:"resultInfos,omitempty"`
+	ResultInfos  []ResultInfos 	   `json:"resultInfos,omitempty"`
 }
 
 type ResultInfos struct {
 	ResourceType     string       `json:"resourceType"`
-	ResourceInfos `json:"resourceInfos"`
+	ResourceInfos    `json:"resourceInfos"`
 }
 
 type ResourceInfos struct {

--- a/controllers/kubeeye/clusterinsigght_status.go
+++ b/controllers/kubeeye/clusterinsigght_status.go
@@ -1,0 +1,68 @@
+package kubeeye
+
+import (
+	kubeeyev1alpha1 "github.com/kubesphere/kubeeye/apis/kubeeye/v1alpha1"
+	"github.com/kubesphere/kubeeye/pkg/kube"
+)
+
+func setClusterInfo(k8SResource kube.K8SResource) (ClusterInfo kubeeyev1alpha1.ClusterInfo) {
+	ClusterInfo.ClusterVersion = k8SResource.ServerVersion
+	ClusterInfo.NodesCount = k8SResource.NodesCount
+	ClusterInfo.NamespacesCount = k8SResource.NameSpacesCount
+	ClusterInfo.NamespacesList = k8SResource.NameSpacesList
+	ClusterInfo.WorkloadsCount = k8SResource.WorkloadsCount
+	return ClusterInfo
+}
+
+func formatResults(receiver <-chan []kubeeyev1alpha1.AuditResults) (formattedResults []kubeeyev1alpha1.AuditResults) {
+	var formattedResult kubeeyev1alpha1.AuditResults
+	fmAuditResults :=  make(map[string][]kubeeyev1alpha1.ResultInfos)
+
+	for results := range receiver {
+		for _ , result := range results {
+			for _, resultInfo := range result.ResultInfos {
+				fmAuditResults[result.NameSpace] = append(fmAuditResults[result.NameSpace], resultInfo)
+			}
+		}
+	}
+
+	for nm, ar := range fmAuditResults {
+		formattedResult.ResultInfos = ar
+		formattedResult.NameSpace = nm
+		formattedResults = append(formattedResults, formattedResult)
+	}
+
+	return formattedResults
+}
+
+func CalculateScore(fmResultss []kubeeyev1alpha1.AuditResults, k8sResources kube.K8SResource) (scoreInfo kubeeyev1alpha1.ScoreInfo) {
+	var countDanger int
+	var countWarning int
+	var countIgnore int
+
+	for _, fmResult := range fmResultss {
+		for _, resultInfo := range fmResult.ResultInfos {
+			for _, item := range resultInfo.ResultItems {
+				if item.Level == "warning" {
+					countWarning++
+				} else if item.Level == "danger" {
+					countDanger++
+				} else if item.Level == "ignore" {
+					countIgnore++
+				}
+			}
+		}
+	}
+
+	total := k8sResources.WorkloadsCount * 20 + (len(k8sResources.Roles.Items) + len(k8sResources.ClusterRoles.Items)) * 3+ len(k8sResources.Events.Items) + len(k8sResources.Nodes.Items) + 1
+	countSuccess := total - countDanger - countWarning - countIgnore
+	totalWeight := countSuccess * 2 + countDanger * 2 + countWarning
+	scoreInfo.Score = countSuccess * 2 * 100 / totalWeight
+	scoreInfo.Total = total
+	scoreInfo.Dangerous = countDanger
+	scoreInfo.Warning = countWarning
+	scoreInfo.Ignore = countIgnore
+	scoreInfo.Passing = countSuccess
+
+	return scoreInfo
+}

--- a/controllers/kubeeye/clusterinsight_controller.go
+++ b/controllers/kubeeye/clusterinsight_controller.go
@@ -25,9 +25,9 @@ import (
 	"github.com/kubesphere/kubeeye/pkg/kube"
 	kubeErr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	kubeeyev1alpha1 "github.com/kubesphere/kubeeye/apis/kubeeye/v1alpha1"
@@ -71,8 +71,8 @@ func (r *ClusterInsightReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	// get kubernetes cluster config
-	//kubeConfig, err := rest.InClusterConfig()
-	kubeConfig, err := config.GetConfig()
+	kubeConfig, err := rest.InClusterConfig()
+	//kubeConfig, err := config.GetConfig()
 	if err != nil {
 		logs.Error(err, "failed to get cluster config")
 		return ctrl.Result{}, err
@@ -89,17 +89,26 @@ func (r *ClusterInsightReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	logs.Info("Starting cluster audit")
 	K8SResources, validationResultsChan := audit.ValidationResults(ctx, clients, "")
 
-	// set cluster info
-	clusterInsight.Status.ClusterInfo = setClusterInfo(K8SResources)
+	// get cluster info
+	clusterInfo := setClusterInfo(K8SResources)
+
+	// fill clusterInsight.Status.ClusterInfo
+	clusterInsight.Status.ClusterInfo = clusterInfo
 
 	// clear clusterInsight.Status.AuditResults
 	clusterInsight.Status.AuditResults = []kubeeyev1alpha1.AuditResults{}
 
 	//format result
-	fmResult := formatResults(validationResultsChan)
+	fmResults := formatResults(validationResultsChan)
 
 	// fill clusterInsight.Status.AuditResults
-	clusterInsight.Status.AuditResults = fmResult
+	clusterInsight.Status.AuditResults = fmResults
+
+	// get score
+	scoreInfo := CalculateScore(fmResults, K8SResources)
+
+	// fill
+	clusterInsight.Status.ScoreInfo = scoreInfo
 
 	// update clusterInsight CR
 	if err := r.Status().Update(ctx, clusterInsight); err != nil {
@@ -128,35 +137,4 @@ func (r *ClusterInsightReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kubeeyev1alpha1.ClusterInsight{}).
 		Complete(r)
-}
-
-func setClusterInfo(k8SResource kube.K8SResource) (ClusterInfo kubeeyev1alpha1.ClusterInfo) {
-	ClusterInfo.ClusterVersion = k8SResource.ServerVersion
-	ClusterInfo.NodesCount = k8SResource.NodesCount
-	ClusterInfo.NamespacesCount = k8SResource.NameSpacesCount
-	ClusterInfo.NamespacesList = k8SResource.NameSpacesList
-	ClusterInfo.WorkloadsCount = k8SResource.WorkloadsCount
-	return ClusterInfo
-}
-
-func formatResults(receiver <-chan []kubeeyev1alpha1.AuditResults) []kubeeyev1alpha1.AuditResults {
-	var formattedResults []kubeeyev1alpha1.AuditResults
-	var formattedResult kubeeyev1alpha1.AuditResults
-	fmAuditResults :=  make(map[string][]kubeeyev1alpha1.ResultInfos)
-
-	for results := range receiver {
-		for _ , result := range results {
-			for _, resultInfo := range result.ResultInfos {
-				fmAuditResults[result.NameSpace] = append(fmAuditResults[result.NameSpace], resultInfo)
-			}
-		}
-	}
-
-	for nm, ar := range fmAuditResults {
-		formattedResult.ResultInfos = ar
-		formattedResult.NameSpace = nm
-		formattedResults = append(formattedResults, formattedResult)
-	}
-
-	return formattedResults
 }

--- a/deploy/kubeeye.yaml
+++ b/deploy/kubeeye.yaml
@@ -50,68 +50,42 @@ spec:
                 format: date-time
                 type: string
               auditResults:
-                properties:
-                  auditResults:
-                    items:
-                      properties:
-                        resourcesType:
-                          type: string
-                        resultInfos:
-                          items:
+                items:
+                  properties:
+                    namespace:
+                      type: string
+                    resultInfos:
+                      items:
+                        properties:
+                          resourceInfos:
                             properties:
-                              namespace:
-                                type: string
-                              resourceInfos:
+                              items:
                                 items:
                                   properties:
-                                    items:
-                                      items:
-                                        properties:
-                                          level:
-                                            type: string
-                                          message:
-                                            type: string
-                                          reason:
-                                            type: string
-                                        type: object
-                                      type: array
-                                    name:
+                                    level:
                                       type: string
-                                  required:
-                                  - items
+                                    message:
+                                      type: string
+                                    reason:
+                                      type: string
                                   type: object
                                 type: array
+                              name:
+                                type: string
                             required:
-                            - namespace
-                            - resourceInfos
+                            - items
                             type: object
-                          type: array
-                      type: object
-                    type: array
-                  namespace:
-                    properties:
-                      dangerous:
-                        format: int32
-                        type: integer
-                      passing:
-                        format: int32
-                        type: integer
-                      score:
-                        format: int32
-                        type: integer
-                      total:
-                        format: int32
-                        type: integer
-                      warning:
-                        format: int32
-                        type: integer
-                    required:
-                    - dangerous
-                    - passing
-                    - total
-                    - warning
-                    type: object
-                type: object
+                          resourceType:
+                            type: string
+                        required:
+                        - resourceInfos
+                        - resourceType
+                        type: object
+                      type: array
+                  required:
+                  - namespace
+                  type: object
+                type: array
               clusterInfo:
                 properties:
                   namespacesCount:
@@ -126,6 +100,26 @@ spec:
                     type: string
                   workloadsCount:
                     type: integer
+                type: object
+              scoreInfo:
+                properties:
+                  dangerous:
+                    type: integer
+                  ignore:
+                    type: integer
+                  passing:
+                    type: integer
+                  score:
+                    type: integer
+                  total:
+                    type: integer
+                  warning:
+                    type: integer
+                required:
+                - dangerous
+                - ignore
+                - passing
+                - warning
                 type: object
             type: object
         type: object
@@ -406,7 +400,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: 140256951yaorui/kubeeye:v0.5.0
+        image: kubesphere/kubeeye:latest
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Cluster health scores are necessary to evaluate the cluster. Through the cluster health score, the user can decide the state of the cluster quickly and proceed to the next step, improving the user's experience on the website.

Signed-off-by: yaorui <yaorui@yunify.com>