### PR TITLE
Fix: check for nil LastScheduleTime

### DIFF
--- a/controllers/auditplan_controller.go
+++ b/controllers/auditplan_controller.go
@@ -89,7 +89,7 @@ func (r *AuditPlanReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	now := time.Now()
 	scheduledTime := nextScheduledTimeDuration(schedule, auditPlan.Status.LastScheduleTime.Time)
-	if auditPlan.Status.LastScheduleTime.Add(*scheduledTime).Before(now) { // if the scheduled time has arrived, create Audit task
+	if auditPlan.Status.LastScheduleTime.IsZero() && auditPlan.Status.LastScheduleTime.Add(*scheduledTime).Before(now) { // if the scheduled time has arrived, create Audit task
 
 		taskName, err := r.createAuditTask(auditPlan, ctx)
 		if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! 

Contents in this block are not visible.

-->

### What type of PR is this?
<!-- 
e.g.
- bugfix
- new-feature
- enhancement
- refactor
- test
- doc
- etc.
-->
- bugfix


### What this PR does / Why we need it:
Check for nil `AuditPlan.Status.LastScheduleTime` to avoid a wrong trigger of AuditTask every time an AuditPlan is synced for the first time.