### PR TITLE
Fix nil pointer dereference in sysctlInspect

### DIFF
--- a/pkg/inspect/sysctl_inspect.go
+++ b/pkg/inspect/sysctl_inspect.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/kubesphere/event-rule-engine/visitor"
 	kubeeyev1alpha2 "github.com/kubesphere/kubeeye/apis/kubeeye/v1alpha2"
 	"github.com/kubesphere/kubeeye/pkg/constant"
@@ -106,7 +107,7 @@ func (o *sysctlInspect) GetResult(runNodeName string, resultCm *corev1.ConfigMap
 }
 
 func parseSysctlVal(val []string) string {
-	if len(val) == 0 && val == nil {
+	if len(val) == 0 || val == nil {
 		return ""
 	}
 	return val[0]


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it:

Fixes the conditional logic in the parseSysctlVal function.
To fix an out-of-bounds access bug when the `val` array is empty.

## Which issue(s) this PR fixes:

Fixes #328 

## Special notes for your reviewer:

@pixiake

help me check the modify, thanks

## Does this PR introduce a user-facing change?:

