### PR TITLE
fix: 解决一次性任务反复执行的bug

### DIFF
--- a/utils/schedule_manager.py
+++ b/utils/schedule_manager.py
@@ -192,8 +192,13 @@ def run_once(task):
     schedule.clear(task.task_id)
     logger.info(f"一次性任务 {task.name} ({task.task_id}) 已执行一次，并已从调度中移除")
 
+_task_locks = {}
 def run_inspection_bg(task):
     """在后台执行巡检任务"""
+    lock = _task_locks.setdefault(task.task_id, threading.Lock())
+    if not lock.acquire(blocking=False):
+        logger.warning(f"任务已在运行，跳过: {task.name} ({task.task_id})")
+        return False
     try:
         logger.info(f"开始执行巡检任务: {task.name} ({task.task_id})")
         
@@ -220,6 +225,8 @@ def run_inspection_bg(task):
         logger.error(error_msg, exc_info=True)  # 添加完整的异常堆栈
         update_task_status(task.task_id, last_status="failed")
         return False
+    finally:
+        lock.release()
 
 def run_inspection(task_id, return_results=False):
     """执行巡检任务
@@ -331,7 +338,7 @@ def schedule_tasks():
             schedule.every().hour.do(
                 lambda t=task: run_inspection_bg(t)
             ).tag(task.task_id)
-            
+
         elif task.task_type == "daily":
             schedule.every().day.at("00:00").do(
                 lambda t=task: run_inspection_bg(t)

--- a/utils/schedule_manager.py
+++ b/utils/schedule_manager.py
@@ -187,6 +187,11 @@ def update_task_status(task_id, last_run=None, last_status=None):
         return add_schedule(task)
     return False
 
+def run_once(task):
+    run_inspection_bg(task)
+    schedule.clear(task.task_id)
+    logger.info(f"一次性任务 {task.name} ({task.task_id}) 已执行一次，并已从调度中移除")
+
 def run_inspection_bg(task):
     """在后台执行巡检任务"""
     try:
@@ -348,10 +353,9 @@ def schedule_tasks():
             if run_time > now:
                 delta_seconds = (run_time - now).total_seconds()
                 schedule.every(int(delta_seconds)).seconds.do(
-                    lambda t=task: run_inspection_bg(t)
+                    lambda t=task: run_once(t)
                 ).tag(task.task_id)
-                logger.info(f"已调度一次性任务: {task.name} ({task.task_id})，将在 {run_time} 执行")
-    
+                logger.info(f"已调度一次性任务: {task.name} ({task.task_id})，将在 {run_time} 执行")        
     logger.info(f"已调度 {len([t for t in tasks if t.enabled])} 个巡检任务")
 
 def reschedule_cron_task(task):


### PR DESCRIPTION
`schedule.every(int(delta_seconds)).seconds.do`不能实现只执行一次，而是每delta_seconds秒执行一次，从而导致once类的任务重复执行，pr完成了修改：任务执行之后删除task。