### PR TITLE
创建定时任务时支持每小时每天等，修改get_next_run逻辑从schedule.jobs中获取

### DIFF
--- a/components/scheduled_scan.py
+++ b/components/scheduled_scan.py
@@ -242,7 +242,7 @@ def render_create_task_tab():
         return
     
     # --- 调度类型选择放到表单外部 ---
-    schedule_types = ["单次定时", "周期定时（Cron表达式）"]
+    schedule_types = ["单次定时","每小时","每天","每周","每月", "周期定时（Cron表达式）"]
     if "schedule_type" not in st.session_state:
         st.session_state["schedule_type"] = schedule_types[0]
     st.session_state["schedule_type"] = st.selectbox(
@@ -359,6 +359,10 @@ def render_create_task_tab():
                 # 确定任务类型和CRON表达式
                 task_type_map = {
                     "单次定时": "once",
+                    "每小时": "hourly",
+                    "每天": "daily",
+                    "每周": "weekly",
+                    "每月": "monthly",
                     "周期定时（Cron表达式）": "cron"
                 }
                 actual_task_type = task_type_map.get(task_type, "cron")

--- a/utils/schedule_manager.py
+++ b/utils/schedule_manager.py
@@ -106,10 +106,9 @@ class ScheduleTask:
     
     def get_next_run(self):
         """获取下次运行时间"""
-        if self.cron_expr and self.is_valid_cron():
-            base = dt.now()
-            itr = croniter(self.cron_expr, base)
-            return itr.get_next(dt)
+        for job in schedule.jobs:
+            if self.task_id in job.tags:
+                return job.next_run
         return None
     
     def get_pretty_schedule(self):


### PR DESCRIPTION
- 定时巡检任务创建ui支持每天、每小时、每周、每月
- 获取任务的下次运行时间从schedule.jobs中读取